### PR TITLE
2 Fixes for that role

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,11 @@
   systemd:
     daemon_reload: true
 
+- name: restart systemd-resolved
+  systemd:
+    name: systemd-resolved
+    state: restarted
+
 - name: restart adguardhome
   service:
     name: "{{ adguardhome_service_name }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -17,7 +17,7 @@
     dest: "{{ adguardhome_unpack_dir }}"
     remote_src: yes
     extra_opts:
-      - "--strip-components=1"
+      - "--strip-components=2"
 
 - name: "Copy binary to {{ adguardhome_bin_dir }}/"
   copy:


### PR DESCRIPTION
Extraction did not work as expected. The it will extract to extract-dir/Adguard/<files> and therefore, always a directory will be copied to the /opt/adguardhome/bin directory.

Second fix adds a missing handler to handlers/main.yml which is used in disable_dnsstubresolver.yml.